### PR TITLE
Configure job class

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Change the factory class in `config/queue.php`:
     ],
 ```
 
-Not all messages will be placed on the queue from a Laravel/Lumen source. In this case, it is helpful to write a custom Job class to be used when processing these messages. To do this, create the new class and ensure it implements the `Illuminate\Contracts\Queue\Job` interface. The, just like with the custom factory class example above, specify this new class in your `config/queue.php` file:
+Not all messages will be placed on the queue from a Laravel/Lumen source. In this case, it is helpful to write a custom Job class to be used when processing these messages. To do this, create the new class and ensure it implements the `Illuminate\Contracts\Queue\Job` interface. Then, just like with the custom factory class example above, specify this new class in your `config/queue.php` file:
 
 ```php
 ...

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ QUEUE_DRIVER=rabbitmq
 RABBITMQ_QUEUE=queue_name
 
 RABBITMQ_DSN=amqp: # same as amqp://guest:guest@127.0.0.1:5672/%2F
-# or 
+# or
 RABBITMQ_HOST=127.0.0.1
 RABBITMQ_PORT=5672
 RABBITMQ_VHOST=/
@@ -49,7 +49,7 @@ Once you completed the configuration you can use Laravel Queue API. If you used 
 
 ## Using other AMQP transports
 
-The package uses [enqueue/amqp-lib](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md) transport which is based on [php-amqplib](https://github.com/php-amqplib/php-amqplib). 
+The package uses [enqueue/amqp-lib](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md) transport which is based on [php-amqplib](https://github.com/php-amqplib/php-amqplib).
 There is possibility to use any [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) compatible transport, for example `enqueue/amqp-ext` or `enqueue/amqp-bunny`.
 Here's an example on how one can change the transport to `enqueue/amqp-bunny`.
 
@@ -58,7 +58,7 @@ First, install desired transport package:
 ```bash
 composer require enqueue/amqp-bunny:^0.8
 ```
-  
+
 Change the factory class in `config/queue.php`:
 
 ```php
@@ -67,6 +67,18 @@ Change the factory class in `config/queue.php`:
         'rabbitmq' => [
             'driver' => 'rabbitmq',
             'factory_class' => Enqueue\AmqpBunny\AmqpConnectionFactory::class,
+        ],
+    ],
+```
+
+Not all messages will be placed on the queue from a Laravel/Lumen source. In this case, it is helpful to write a custom Job class to be used when processing these messages. To do this, create the new class and ensure it implements the `Illuminate\Contracts\Queue\Job` interface. The, just like with the custom factory class example above, specify this new class in your `config/queue.php` file:
+
+```php
+...
+    'connections' => [
+        'rabbitmq' => [
+            'driver' => 'rabbitmq',
+            'job_class' => My\Custom\Queued\Job::class,
         ],
     ],
 ```

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -19,6 +19,12 @@ return [
      */
     'factory_class' => Enqueue\AmqpLib\AmqpConnectionFactory::class,
 
+    /*
+     * You can override the class used to process the payload as it is pulled off the queue
+     * Just be sure that whatever you choose implements the `Illuminate\Contracts\Queue\Job` interface
+     */
+    'job_class' => VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Jobs\RabbitMQJob::class,
+
     'host' => env('RABBITMQ_HOST', '127.0.0.1'),
     'port' => env('RABBITMQ_PORT', 5672),
 


### PR DESCRIPTION
This PR allows an end user to specify a custom job class to be created when processing messages off the queue.

For my use-case, we have a fanout queue that distributes messages created by other systems (some PHP systems, some Java systems, etc). By specifying a custom class, I can easily process those messages without having them change their format to fit the Laravel/Lumen way of doing things.